### PR TITLE
Rename chart page and externalize graph data

### DIFF
--- a/about.html
+++ b/about.html
@@ -56,7 +56,7 @@
       <a href="about.html">关于我们</a>
       <a href="library.html">在线文库</a>
       <a href="events.html">活动日历</a>
-      <a href="graph.html">图表页</a>
+      <a href="graph.html">哲学图谱</a>
       <a href="contact.html">联系方式</a>
     </div>
     <div class="content">

--- a/contact.html
+++ b/contact.html
@@ -56,7 +56,7 @@
       <a href="about.html">关于我们</a>
       <a href="library.html">在线文库</a>
       <a href="events.html">活动日历</a>
-      <a href="graph.html">图表页</a>
+      <a href="graph.html">哲学图谱</a>
       <a href="contact.html">联系方式</a>
     </div>
     <div class="content">

--- a/data/graphData.json
+++ b/data/graphData.json
@@ -1,0 +1,37 @@
+{
+  "nodes": [
+    { "id": "Thales", "label": "泰勒斯 - 水是万物的本原", "year": -585 },
+    { "id": "Anaximander", "label": "阿纳克西曼德 - 无定形 Apeiron", "year": -570 },
+    { "id": "Anaximenes", "label": "阿纳克西美尼 - 气为本原", "year": -550 },
+    { "id": "Heraclitus", "label": "赫拉克利特 - 火与流变，logos", "year": -500 },
+    { "id": "Xenophanes", "label": "色诺芬尼 - 存在转向", "year": -520 },
+    { "id": "Parmenides", "label": "巴门尼德 - 存在是一", "year": -480 },
+    { "id": "Empedocles", "label": "恩培多克勒 - 四根与爱/冲突", "year": -460 },
+    { "id": "Anaxagoras", "label": "阿那克萨戈拉 - 种子与 Nous", "year": -460 },
+    { "id": "Democritus", "label": "德谟克里特 - 原子论", "year": -430 },
+    { "id": "Socrates", "label": "苏格拉底 - 伦理辩证法", "year": -470 },
+    { "id": "Plato", "label": "柏拉图 - 理念论", "year": -428 },
+    { "id": "Aristotle", "label": "亚里士多德 - 实体论", "year": -384 },
+    { "id": "Zeno_of_Citium", "label": "芝诺（斯多葛派） - 物质性与 logos", "year": -300 },
+    { "id": "Epicurus", "label": "伊壁鸠鲁 - 原子偶然性，快乐主义", "year": -310 },
+    { "id": "Pyrrho", "label": "皮浪（怀疑派） - 悬搁判断", "year": -315 },
+    { "id": "Plotinus", "label": "普罗提诺（新柏拉图主义） - 太一流溢说", "year": 240 }
+  ],
+  "links": [
+    { "source": "Thales", "target": "Anaximander", "description": "阿纳克西曼德是泰勒斯的学生" },
+    { "source": "Anaximander", "target": "Anaximenes", "description": "阿纳克西美尼是阿纳克西曼德的学生" },
+    { "source": "Xenophanes", "target": "Parmenides", "description": "巴门尼德继承色诺芬尼的存在论转向" },
+    { "source": "Heraclitus", "target": "Parmenides", "description": "赫拉克利特与巴门尼德思想对立" },
+    { "source": "Parmenides", "target": "Empedocles", "description": "恩培多克勒受巴门尼德影响" },
+    { "source": "Parmenides", "target": "Anaxagoras", "description": "阿那克萨戈拉受巴门尼德影响" },
+    { "source": "Parmenides", "target": "Democritus", "description": "德谟克里特受巴门尼德影响" },
+    { "source": "Socrates", "target": "Plato", "description": "柏拉图是苏格拉底的学生" },
+    { "source": "Plato", "target": "Aristotle", "description": "亚里士多德是柏拉图的学生" },
+    { "source": "Heraclitus", "target": "Zeno_of_Citium", "description": "斯多葛派继承赫拉克利特的 logos" },
+    { "source": "Socrates", "target": "Zeno_of_Citium", "description": "斯多葛派受苏格拉底伦理学影响" },
+    { "source": "Democritus", "target": "Epicurus", "description": "伊壁鸠鲁继承德谟克里特原子论" },
+    { "source": "Zeno_of_Citium", "target": "Pyrrho", "description": "皮浪批判斯多葛派的 logos" },
+    { "source": "Epicurus", "target": "Pyrrho", "description": "皮浪批判伊壁鸠鲁的原子论" },
+    { "source": "Plato", "target": "Plotinus", "description": "普罗提诺继承柏拉图理念论" }
+  ]
+}

--- a/events.html
+++ b/events.html
@@ -56,7 +56,7 @@
       <a href="about.html">关于我们</a>
       <a href="library.html">在线文库</a>
       <a href="events.html">活动日历</a>
-      <a href="graph.html">图表页</a>
+      <a href="graph.html">哲学图谱</a>
       <a href="contact.html">联系方式</a>
     </div>
     <div class="content">

--- a/graph.html
+++ b/graph.html
@@ -2,47 +2,89 @@
 <html lang="zh">
 <head>
   <meta charset="UTF-8">
-  <title>哲学家关系图谱 Demo</title>
+  <title>哲学图谱</title>
   <style>
-    html, body { margin: 0; height: 100%; overflow: hidden; font-family: sans-serif; }
-    #container { display: flex; height: 100%; }
-    .axis svg {
-      background: #f0f0f0;
-      display: block;
-    }
-    #graph-container { flex: 1; position: relative; }
-    .tooltip {
-      position: absolute;
-      background: white;
-      border: 1px solid #ccc;
-      padding: 8px;
-      border-radius: 4px;
-      box-shadow: 0 2px 6px rgba(0,0,0,0.2);
-      display: none;
-      font-size: 14px;
-      pointer-events: auto;
-    }
-    .tooltip a {
-      color: #0066cc;
-      text-decoration: none;
-    }
-    .tooltip a:hover {
-      text-decoration: underline;
-    }
-    svg text {
-      font-size: 12px;
-    }
-    circle {
-      vector-effect: non-scaling-stroke;
-      stroke: #333;
-      stroke-width: 1;
-    }
-    line {
-      vector-effect: non-scaling-stroke;
-    }
+      body {
+        font-family: Arial, sans-serif;
+        margin: 0;
+        padding: 0;
+      }
+      .header {
+        background-color: #f1f1f1;
+        padding: 20px;
+        text-align: center;
+      }
+      .nav-bar {
+        background-color: #333;
+        overflow: hidden;
+      }
+      .nav-bar a {
+        float: left;
+        color: white;
+        text-align: center;
+        padding: 14px 16px;
+        text-decoration: none;
+      }
+      .nav-bar a:hover {
+        background-color: #ddd;
+        color: black;
+      }
+      .motto {
+        margin-top: 10px;
+        font-style: italic;
+      }
+      #container { display: flex; height: calc(100vh - 160px); }
+      .axis svg {
+        background: #f0f0f0;
+        display: block;
+      }
+      #graph-container { flex: 1; position: relative; }
+      .tooltip {
+        position: absolute;
+        background: white;
+        border: 1px solid #ccc;
+        padding: 8px;
+        border-radius: 4px;
+        box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+        display: none;
+        font-size: 14px;
+        pointer-events: auto;
+      }
+      .tooltip a {
+        color: #0066cc;
+        text-decoration: none;
+      }
+      .tooltip a:hover {
+        text-decoration: underline;
+      }
+      svg text {
+        font-size: 12px;
+      }
+      circle {
+        vector-effect: non-scaling-stroke;
+        stroke: #333;
+        stroke-width: 1;
+      }
+      line {
+        vector-effect: non-scaling-stroke;
+      }
   </style>
 </head>
 <body>
+<div class="header">
+  <h1>哈三中哲学社团（网站建设中！）</h1>
+  <span>随机格言：</span>
+  <p class="motto" id="motto"></p>
+</div>
+
+<div class="nav-bar">
+  <a href="index.html">首页</a>
+  <a href="about.html">关于我们</a>
+  <a href="library.html">在线文库</a>
+  <a href="events.html">活动日历</a>
+  <a href="graph.html">哲学图谱</a>
+  <a href="contact.html">联系方式</a>
+</div>
 <div id="container">
   <div class="axis">
     <svg id="axis-svg" width="160" height="1000"></svg>
@@ -52,43 +94,9 @@
 <div class="tooltip" id="tooltip"></div>
 <script src="https://d3js.org/d3.v7.min.js"></script>
 <script>
-const data = {
-  nodes: [
-    { id: 'Thales', label: '泰勒斯 - 水是万物的本原', year: -585 },
-    { id: 'Anaximander', label: '阿纳克西曼德 - 无定形 Apeiron', year: -570 },
-    { id: 'Anaximenes', label: '阿纳克西美尼 - 气为本原', year: -550 },
-    { id: 'Heraclitus', label: '赫拉克利特 - 火与流变，logos', year: -500 },
-    { id: 'Xenophanes', label: '色诺芬尼 - 存在转向', year: -520 },
-    { id: 'Parmenides', label: '巴门尼德 - 存在是一', year: -480 },
-    { id: 'Empedocles', label: '恩培多克勒 - 四根与爱/冲突', year: -460 },
-    { id: 'Anaxagoras', label: '阿那克萨戈拉 - 种子与 Nous', year: -460 },
-    { id: 'Democritus', label: '德谟克里特 - 原子论', year: -430 },
-    { id: 'Socrates', label: '苏格拉底 - 伦理辩证法', year: -470 },
-    { id: 'Plato', label: '柏拉图 - 理念论', year: -428 },
-    { id: 'Aristotle', label: '亚里士多德 - 实体论', year: -384 },
-    { id: 'Zeno_of_Citium', label: '芝诺（斯多葛派） - 物质性与 logos', year: -300 },
-    { id: 'Epicurus', label: '伊壁鸠鲁 - 原子偶然性，快乐主义', year: -310 },
-    { id: 'Pyrrho', label: '皮浪（怀疑派） - 悬搁判断', year: -315 },
-    { id: 'Plotinus', label: '普罗提诺（新柏拉图主义） - 太一流溢说', year: 240 }
-  ],
-  links: [
-    { source: 'Thales', target: 'Anaximander', description: '阿纳克西曼德是泰勒斯的学生' },
-    { source: 'Anaximander', target: 'Anaximenes', description: '阿纳克西美尼是阿纳克西曼德的学生' },
-    { source: 'Xenophanes', target: 'Parmenides', description: '巴门尼德继承色诺芬尼的存在论转向' },
-    { source: 'Heraclitus', target: 'Parmenides', description: '赫拉克利特与巴门尼德思想对立' },
-    { source: 'Parmenides', target: 'Empedocles', description: '恩培多克勒受巴门尼德影响' },
-    { source: 'Parmenides', target: 'Anaxagoras', description: '阿那克萨戈拉受巴门尼德影响' },
-    { source: 'Parmenides', target: 'Democritus', description: '德谟克里特受巴门尼德影响' },
-    { source: 'Socrates', target: 'Plato', description: '柏拉图是苏格拉底的学生' },
-    { source: 'Plato', target: 'Aristotle', description: '亚里士多德是柏拉图的学生' },
-    { source: 'Heraclitus', target: 'Zeno_of_Citium', description: '斯多葛派继承赫拉克利特的 logos' },
-    { source: 'Socrates', target: 'Zeno_of_Citium', description: '斯多葛派受苏格拉底伦理学影响' },
-    { source: 'Democritus', target: 'Epicurus', description: '伊壁鸠鲁继承德谟克里特原子论' },
-    { source: 'Zeno_of_Citium', target: 'Pyrrho', description: '皮浪批判斯多葛派的 logos' },
-    { source: 'Epicurus', target: 'Pyrrho', description: '皮浪批判伊壁鸠鲁的原子论' },
-    { source: 'Plato', target: 'Plotinus', description: '普罗提诺继承柏拉图理念论' }
-  ]
-};
+fetch("data/graphData.json")
+  .then(response => response.json())
+  .then(data => {
 
 const width = window.innerWidth;
 const height = window.innerHeight;
@@ -298,6 +306,8 @@ const zoom = d3.zoom()
   });
 
 d3.select('#container').call(zoom);
+});
 </script>
+<script src="files/js/motto.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
       <a href="about.html">关于我们</a>
       <a href="library.html">在线文库</a>
       <a href="events.html">活动日历</a>
-      <a href="graph.html">图表页</a>
+      <a href="graph.html">哲学图谱</a>
       <a href="contact.html">联系方式</a>
     </div>
 

--- a/library.html
+++ b/library.html
@@ -56,7 +56,7 @@
       <a href="about.html">关于我们</a>
       <a href="library.html">在线文库</a>
       <a href="events.html">活动日历</a>
-      <a href="graph.html">图表页</a>
+      <a href="graph.html">哲学图谱</a>
       <a href="contact.html">联系方式</a>
     </div>
     <div class="content">


### PR DESCRIPTION
## Summary
- rename nav link from 图表页 to 哲学图谱
- add header and navigation to `graph.html`
- store graph nodes and links in `data/graphData.json`
- load data via `fetch` in `graph.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d088161248331bc866128f195a15b